### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/controller_profile_edit.xml
+++ b/app/src/main/res/layout/controller_profile_edit.xml
@@ -175,6 +175,7 @@
           android:hint="@string/hint_profile_edit_password"
           android:imeOptions="actionNext"
           android:inputType="textPassword"
+          android:importantForAccessibility="no"
           android:maxLines="1" />
       </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/controller_sign_in.xml
+++ b/app/src/main/res/layout/controller_sign_in.xml
@@ -76,6 +76,7 @@
           android:imeActionId="@+id/sign_up"
           android:imeActionLabel="@string/action_sing_up_short"
           android:inputType="textPassword"
+          android:importantForAccessibility="no"
           android:maxLines="1" />
 
         <Button

--- a/app/src/main/res/layout/controller_sign_up.xml
+++ b/app/src/main/res/layout/controller_sign_up.xml
@@ -137,7 +137,8 @@
           android:drawableStart="@drawable/ic_lock_black_24dp"
           android:hint="@string/hint_password"
           android:inputType="textPassword"
-          android:maxLines="1" />
+          android:maxLines="1"
+          android:importantForAccessibility="no" />
 
       </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.